### PR TITLE
Implement issue command

### DIFF
--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -5,22 +5,37 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+
+	"orecert/internal/issue"
 )
 
 // issueCmd represents the issue command
 var issueCmd = &cobra.Command{
 	Use:   "issue",
 	Short: "鍵+CSR+証明書生成",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("issue called")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		typ, _ := cmd.Flags().GetString("type")
+		if len(args) != 1 {
+			return fmt.Errorf("profile required")
+		}
+		var cfg issue.Config
+		if err := viper.Unmarshal(&cfg); err != nil {
+			return err
+		}
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			return err
+		}
+		var prof issue.Profile
+		if err := yaml.Unmarshal(data, &prof); err != nil {
+			return err
+		}
+		return issue.Issue(cfg, prof, typ)
 	},
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"orecert/internal/ca"
+)
+
+func TestExecute_Help(t *testing.T) {
+	rootCmd.SetArgs([]string{"--help"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute help: %v", err)
+	}
+}
+
+func TestIssueCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfg := ca.Config{}
+	cfg.CA.Key = filepath.Join(dir, "certs", "ca", "key.pem")
+	cfg.CA.Cert = filepath.Join(dir, "certs", "ca", "cert.pem")
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ca.InitCA(cfg); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(".orecert.yaml", []byte("{}"), 0644)
+	profile := filepath.Join(dir, "p.yml")
+	os.WriteFile(profile, []byte("cn: test"), 0644)
+
+	rootCmd.SetArgs([]string{"-c", ".orecert.yaml", "issue", profile})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute issue: %v", err)
+	}
+}
+
+func TestOtherCommands(t *testing.T) {
+	cmds := [][]string{
+		{"version"},
+		{"bundle"},
+		{"verify"},
+		{"revoke"},
+	}
+	for _, c := range cmds {
+		rootCmd.SetArgs(c)
+		rootCmd.Execute()
+	}
+}

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -61,3 +61,47 @@ func TestInitCA_OverwriteFalse(t *testing.T) {
 		t.Fatalf("expected error when files exist without overwrite")
 	}
 }
+
+func TestGenerateKeyVariants(t *testing.T) {
+	if _, _, err := ca.GenerateKey("rsa"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ca.GenerateKey("ecdsa"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ca.GenerateKey("ed25519"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWriteAndExists(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "k.pem")
+	priv, _, _ := ca.GenerateKey("rsa")
+	if err := ca.WriteKey(keyPath, priv); err != nil {
+		t.Fatal(err)
+	}
+	if !ca.Exists(keyPath) {
+		t.Fatal("file should exist")
+	}
+}
+
+func TestPkixName(t *testing.T) {
+	n := ca.PkixName()
+	if n.CommonName == "" {
+		t.Fatal("empty cn")
+	}
+}
+
+func TestEllipticP256(t *testing.T) {
+	c := ca.EllipticP256()
+	if c.Params().Name != "P-256" {
+		t.Fatal("not p256")
+	}
+}
+
+func TestWriteKeyError(t *testing.T) {
+	if err := ca.WriteKey(filepath.Join(t.TempDir(), "x"), struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/issue/issue.go
+++ b/internal/issue/issue.go
@@ -1,0 +1,370 @@
+package issue
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	DefaultAlgo string `mapstructure:"default_algo"`
+	DefaultDays int    `mapstructure:"default_days"`
+	Overwrite   bool   `mapstructure:"overwrite"`
+	CA          struct {
+		Key  string `mapstructure:"key"`
+		Cert string `mapstructure:"cert"`
+	} `mapstructure:"ca"`
+}
+
+// Profile はプロファイルYAMLの内容を表します。
+type Profile struct {
+	CN      string   `mapstructure:"cn"`
+	SAN     []string `mapstructure:"san"`
+	Algo    string   `mapstructure:"algo"`
+	RSABits int      `mapstructure:"rsa_bits"`
+	Days    int      `mapstructure:"days"`
+}
+
+var (
+	ErrInvalidCN   = errors.New("invalid cn")
+	ErrInvalidType = errors.New("invalid type")
+	ErrExists      = errors.New("files exist and overwrite disabled")
+)
+
+// Issue は鍵と証明書を生成します。
+func Issue(cfg Config, prof Profile, typ string) error {
+	if typ != "server" && typ != "client" && typ != "both" {
+		return ErrInvalidType
+	}
+	if prof.CN == "" || strings.Contains(prof.CN, "..") || strings.ContainsAny(prof.CN, "/\\") {
+		return ErrInvalidCN
+	}
+
+	if cfg.DefaultAlgo == "" {
+		cfg.DefaultAlgo = "rsa"
+	}
+	if cfg.DefaultDays == 0 {
+		cfg.DefaultDays = 825
+	}
+	if cfg.CA.Key == "" {
+		cfg.CA.Key = filepath.FromSlash("certs/ca/key.pem")
+	}
+	if cfg.CA.Cert == "" {
+		cfg.CA.Cert = filepath.FromSlash("certs/ca/cert.pem")
+	}
+
+	algo := prof.Algo
+	if algo == "" {
+		algo = cfg.DefaultAlgo
+	}
+	days := prof.Days
+	if days == 0 {
+		days = cfg.DefaultDays
+	}
+	bits := prof.RSABits
+	if bits == 0 {
+		bits = 2048
+	}
+
+	if err := os.MkdirAll(filepath.Join("certs", prof.CN), 0755); err != nil {
+		return err
+	}
+
+	keyPath := filepath.Join("certs", prof.CN, "key.pem")
+	csrPath := filepath.Join("certs", prof.CN, "csr.pem")
+	certPath := filepath.Join("certs", prof.CN, "cert.pem")
+	chainPath := filepath.Join("certs", prof.CN, "fullchain.pem")
+	metaPath := filepath.Join("certs", prof.CN, "meta.json")
+
+	if !cfg.Overwrite {
+		for _, p := range []string{keyPath, csrPath, certPath, chainPath, metaPath} {
+			if exists(p) {
+				return ErrExists
+			}
+		}
+	}
+
+	priv, pub, err := GenerateKey(algo, bits)
+	if err != nil {
+		return err
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject:        pkix.Name{CommonName: prof.CN},
+		DNSNames:       ParseDNS(prof.SAN),
+		IPAddresses:    ParseIP(prof.SAN),
+		URIs:           ParseURI(prof.SAN),
+		EmailAddresses: ParseEmail(prof.SAN),
+	}, priv)
+	if err != nil {
+		return err
+	}
+
+	caCert, err := ReadCert(cfg.CA.Cert)
+	if err != nil {
+		return err
+	}
+	caKey, err := ReadKey(cfg.CA.Key)
+	if err != nil {
+		return err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:   randomSerial(),
+		Subject:        pkix.Name{CommonName: prof.CN},
+		NotBefore:      time.Now(),
+		NotAfter:       time.Now().AddDate(0, 0, days),
+		DNSNames:       ParseDNS(prof.SAN),
+		IPAddresses:    ParseIP(prof.SAN),
+		URIs:           ParseURI(prof.SAN),
+		EmailAddresses: ParseEmail(prof.SAN),
+	}
+	tmpl.ExtKeyUsage, tmpl.KeyUsage = usageByType(typ, algo)
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, pub, caKey)
+	if err != nil {
+		return err
+	}
+
+	if err := WriteKey(keyPath, priv); err != nil {
+		return err
+	}
+	if err := os.WriteFile(csrPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}), 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0644); err != nil {
+		return err
+	}
+	full := append(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})...)
+	if err := os.WriteFile(chainPath, full, 0644); err != nil {
+		return err
+	}
+
+	meta := map[string]any{
+		"cn":                 prof.CN,
+		"type":               typ,
+		"algorithm":          AlgoString(algo, bits),
+		"fingerprint_sha256": Fingerprint(certDER),
+		"not_before":         tmpl.NotBefore.Format(time.RFC3339),
+		"not_after":          tmpl.NotAfter.Format(time.RFC3339),
+		"san":                prof.SAN,
+		"serial_hex":         strings.ToUpper(tmpl.SerialNumber.Text(16)),
+		"key_encrypted":      false,
+	}
+	metaBytes, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(metaPath, metaBytes, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func usageByType(t, algo string) ([]x509.ExtKeyUsage, x509.KeyUsage) {
+	var eku []x509.ExtKeyUsage
+	switch t {
+	case "server":
+		eku = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	case "client":
+		eku = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	case "both":
+		eku = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	}
+	ku := x509.KeyUsageDigitalSignature
+	if algo != "ed25519" && t != "client" {
+		ku |= x509.KeyUsageKeyEncipherment
+	}
+	return eku, ku
+}
+
+// ParseDNS は SAN から DNS エントリを抽出します。
+func ParseDNS(san []string) []string {
+	var out []string
+	for _, s := range san {
+		if strings.HasPrefix(s, "DNS:") {
+			out = append(out, strings.TrimPrefix(s, "DNS:"))
+		}
+	}
+	return out
+}
+
+// ParseIP は SAN から IP アドレスを抽出します。
+func ParseIP(san []string) []net.IP {
+	var out []net.IP
+	for _, s := range san {
+		if strings.HasPrefix(s, "IP:") {
+			if ip := net.ParseIP(strings.TrimPrefix(s, "IP:")); ip != nil {
+				out = append(out, ip)
+			}
+		}
+	}
+	return out
+}
+
+// ParseURI は SAN から URI を抽出します。
+func ParseURI(san []string) []*url.URL {
+	var out []*url.URL
+	for _, s := range san {
+		if strings.HasPrefix(s, "URI:") {
+			if u, err := url.Parse(strings.TrimPrefix(s, "URI:")); err == nil {
+				out = append(out, u)
+			}
+		}
+	}
+	return out
+}
+
+// ParseEmail は SAN からメールアドレスを抽出します。
+func ParseEmail(san []string) []string {
+	var out []string
+	for _, s := range san {
+		if strings.HasPrefix(s, "EMAIL:") {
+			out = append(out, strings.TrimPrefix(s, "EMAIL:"))
+		}
+	}
+	return out
+}
+
+// GenerateKey は指定アルゴリズムで鍵ペアを生成します。
+func GenerateKey(algo string, bits int) (any, any, error) {
+	switch algo {
+	case "rsa", "":
+		priv, err := rsa.GenerateKey(rand.Reader, bits)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, &priv.PublicKey, nil
+	case "ecdsa":
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, &priv.PublicKey, nil
+	case "ed25519":
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, pub, nil
+	default:
+		return nil, nil, errors.New("unsupported algo")
+	}
+}
+
+// WriteKey は秘密鍵を PEM 形式で保存します。
+func WriteKey(path string, key any) error {
+	var block *pem.Block
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		block = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return err
+		}
+		block = &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	case ed25519.PrivateKey:
+		b, err := x509.MarshalPKCS8PrivateKey(k)
+		if err != nil {
+			return err
+		}
+		block = &pem.Block{Type: "PRIVATE KEY", Bytes: b}
+	default:
+		return errors.New("unknown key type")
+	}
+	return os.WriteFile(path, pem.EncodeToMemory(block), 0600)
+}
+
+// ReadCert は PEM 形式の証明書を読み込みます。
+func ReadCert(path string) (*x509.Certificate, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	blk, _ := pem.Decode(b)
+	if blk == nil {
+		return nil, errors.New("failed to decode pem")
+	}
+	return x509.ParseCertificate(blk.Bytes)
+}
+
+// ReadKey は PEM 形式の秘密鍵を読み込みます。
+func ReadKey(path string) (any, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	blk, _ := pem.Decode(b)
+	if blk == nil {
+		return nil, errors.New("failed to decode pem")
+	}
+	switch blk.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(blk.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(blk.Bytes)
+	case "PRIVATE KEY":
+		return x509.ParsePKCS8PrivateKey(blk.Bytes)
+	default:
+		return nil, errors.New("unknown key type")
+	}
+}
+
+// Fingerprint は証明書 DER から SHA256 指紋を作成します。
+func Fingerprint(der []byte) string {
+	h := sha256.Sum256(der)
+	hexstr := strings.ToUpper(hex.EncodeToString(h[:]))
+	var b strings.Builder
+	for i := 0; i < len(hexstr); i += 2 {
+		if i > 0 {
+			b.WriteString(":")
+		}
+		b.WriteString(hexstr[i : i+2])
+	}
+	return b.String()
+}
+
+// AlgoString はアルゴリズム表示名を返します。
+func AlgoString(algo string, bits int) string {
+	switch algo {
+	case "rsa", "":
+		return fmt.Sprintf("RSA-%d", bits)
+	case "ecdsa":
+		return "ECDSA-P256"
+	case "ed25519":
+		return "Ed25519"
+	default:
+		return algo
+	}
+}
+
+// exists はファイル存在確認を行います。
+func exists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// randomSerial は 128bit のランダムシリアル番号を生成します。
+func randomSerial() *big.Int {
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	return serial
+}

--- a/internal/issue/issue_test.go
+++ b/internal/issue/issue_test.go
@@ -1,0 +1,186 @@
+package issue_test
+
+import (
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"orecert/internal/ca"
+	"orecert/internal/issue"
+)
+
+func createCA(t *testing.T, dir string) issue.Config {
+	t.Helper()
+	cfg := issue.Config{}
+	cfg.CA.Key = filepath.Join(dir, "certs", "ca", "key.pem")
+	cfg.CA.Cert = filepath.Join(dir, "certs", "ca", "cert.pem")
+	if err := ca.InitCA(ca.Config{CA: cfg.CA}); err != nil {
+		t.Fatalf("init ca: %v", err)
+	}
+	return cfg
+}
+
+func TestIssue_GeneratesFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	cfg.Overwrite = false
+
+	prof := issue.Profile{CN: "localhost", SAN: []string{"DNS:localhost"}}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := issue.Issue(cfg, prof, "server"); err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	paths := []string{
+		filepath.Join("certs", "localhost", "key.pem"),
+		filepath.Join("certs", "localhost", "csr.pem"),
+		filepath.Join("certs", "localhost", "cert.pem"),
+		filepath.Join("certs", "localhost", "fullchain.pem"),
+		filepath.Join("certs", "localhost", "meta.json"),
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("%s not created", p)
+		}
+	}
+}
+
+func TestIssue_OverwriteCheck(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+
+	prof := issue.Profile{CN: "dup"}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// first run
+	if err := issue.Issue(cfg, prof, "client"); err != nil {
+		t.Fatal(err)
+	}
+	// second run without overwrite should fail
+	if err := issue.Issue(cfg, prof, "client"); err != issue.ErrExists {
+		t.Fatalf("expected ErrExists, got %v", err)
+	}
+}
+
+func TestIssue_InvalidCN(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	prof := issue.Profile{CN: "../bad"}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := issue.Issue(cfg, prof, "server"); err != issue.ErrInvalidCN {
+		t.Fatalf("expected ErrInvalidCN, got %v", err)
+	}
+}
+
+func TestIssue_InvalidType(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	prof := issue.Profile{CN: "x"}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := issue.Issue(cfg, prof, "bad"); err != issue.ErrInvalidType {
+		t.Fatalf("expected ErrInvalidType, got %v", err)
+	}
+}
+
+func TestFingerprintFormat(t *testing.T) {
+	block := &pem.Block{Type: "CERTIFICATE", Bytes: []byte("dummy")}
+	got := issue.Fingerprint(pem.EncodeToMemory(block))
+	if len(got) == 0 {
+		t.Fatal("fingerprint empty")
+	}
+}
+
+func TestParseHelpers(t *testing.T) {
+	dns := issue.ParseDNS([]string{"DNS:a"})
+	if len(dns) != 1 || dns[0] != "a" {
+		t.Fatalf("parse dns failed")
+	}
+	ips := issue.ParseIP([]string{"IP:127.0.0.1"})
+	if len(ips) != 1 || ips[0].String() != "127.0.0.1" {
+		t.Fatalf("parse ip failed")
+	}
+	uris := issue.ParseURI([]string{"URI:https://example.com"})
+	if len(uris) != 1 || uris[0].Host != "example.com" {
+		t.Fatalf("parse uri failed")
+	}
+	emails := issue.ParseEmail([]string{"EMAIL:a@example.com"})
+	if len(emails) != 1 || emails[0] != "a@example.com" {
+		t.Fatalf("parse email failed")
+	}
+}
+
+func TestAlgoString(t *testing.T) {
+	if issue.AlgoString("rsa", 2048) != "RSA-2048" {
+		t.Fatal("algostring rsa")
+	}
+	if issue.AlgoString("ecdsa", 0) != "ECDSA-P256" {
+		t.Fatal("algostring ecdsa")
+	}
+	if issue.AlgoString("ed25519", 0) != "Ed25519" {
+		t.Fatal("algostring ed25519")
+	}
+}
+
+func TestHelpers(t *testing.T) {
+	algos := []string{"rsa", "ecdsa", "ed25519"}
+	for _, a := range algos {
+		priv, pub, err := issue.GenerateKey(a, 2048)
+		if err != nil || priv == nil || pub == nil {
+			t.Fatalf("generate %s", a)
+		}
+		path := filepath.Join(t.TempDir(), a+".pem")
+		if err := issue.WriteKey(path, priv); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := issue.ReadKey(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestGenerateKeyAlgorithms(t *testing.T) {
+	algos := []string{"rsa", "ecdsa", "ed25519"}
+	for _, a := range algos {
+		priv, pub, err := issue.GenerateKey(a, 2048)
+		if err != nil || priv == nil || pub == nil {
+			t.Fatalf("key gen %s", a)
+		}
+	}
+}
+
+func TestReadCert(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	cert, err := issue.ReadCert(cfg.CA.Cert)
+	if err != nil || cert == nil {
+		t.Fatal("read cert fail")
+	}
+}
+
+func TestErrorBranches(t *testing.T) {
+	if _, _, err := issue.GenerateKey("bad", 0); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := issue.WriteKey(filepath.Join(t.TempDir(), "k"), struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
+	badKey := filepath.Join(t.TempDir(), "bad.pem")
+	os.WriteFile(badKey, []byte("BAD"), 0644)
+	if _, err := issue.ReadKey(badKey); err == nil {
+		t.Fatal("expected read error")
+	}
+	if _, err := issue.ReadCert(badKey); err == nil {
+		t.Fatal("expected read cert error")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestMainFunc(t *testing.T) {
+	main()
+}


### PR DESCRIPTION
## Summary
- add issue command implementation with key and certificate generation
- create new issue package with helpers and tests
- expand CA helpers and tests
- add basic CLI tests and main test

## Testing
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_687b546460308320bf7c0062ae421e2b