### PR TITLE
Implement revoke and version command

### DIFF
--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -5,22 +5,41 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+
+	"orecert/internal/revoke"
 )
 
 // revokeCmd represents the revoke command
 var revokeCmd = &cobra.Command{
-	Use:   "revoke",
+	Use:   "revoke [profile]",
 	Short: "証明書失効 & CRL 更新",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("revoke called")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("profile required")
+		}
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			return err
+		}
+		var prof revoke.Profile
+		if err := yaml.Unmarshal(data, &prof); err != nil {
+			return err
+		}
+		var cfg revoke.Config
+		if err := viper.Unmarshal(&cfg); err != nil {
+			return err
+		}
+		if err := revoke.Revoke(cfg, prof); err != nil {
+			return err
+		}
+		fmt.Println("✅", filepath.Join("certs", prof.CN, "cert.pem"))
+		return nil
 	},
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -58,6 +58,30 @@ func TestIssueCommand(t *testing.T) {
 	}
 }
 
+func TestRevokeCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfg := ca.Config{}
+	cfg.CA.Key = filepath.Join(dir, "certs", "ca", "key.pem")
+	cfg.CA.Cert = filepath.Join(dir, "certs", "ca", "cert.pem")
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ca.InitCA(cfg); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(".orecert.yaml", []byte("{}"), 0644)
+	profile := filepath.Join(dir, "r.yml")
+	os.WriteFile(profile, []byte("cn: r"), 0644)
+	rootCmd.SetArgs([]string{"-c", ".orecert.yaml", "issue", profile})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	rootCmd.SetArgs([]string{"-c", ".orecert.yaml", "revoke", profile})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+}
+
 func TestOtherCommands(t *testing.T) {
 	cmds := [][]string{
 		{"version"},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,23 +4,17 @@ Copyright © 2025 ramsesyok
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 // versionCmd represents the version command
+const Version = "0.1.0"
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "バージョン表示",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("version called")
+		cmd.Println(Version)
 	},
 }
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestVersionCommand(t *testing.T) {
+	buf := new(bytes.Buffer)
+	versionCmd.SetOut(buf)
+	versionCmd.Run(versionCmd, []string{})
+	if buf.String() != Version+"\n" {
+		t.Fatalf("version output mismatch: %s", buf.String())
+	}
+}

--- a/internal/revoke/revoke.go
+++ b/internal/revoke/revoke.go
@@ -1,0 +1,96 @@
+package revoke
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"orecert/internal/issue"
+)
+
+// Config は revoke 用設定です。
+type Config struct {
+	CA struct {
+		Key  string `mapstructure:"key"`
+		Cert string `mapstructure:"cert"`
+	} `mapstructure:"ca"`
+}
+
+// Profile は CN を保持します。
+type Profile struct {
+	CN string `mapstructure:"cn"`
+}
+
+// Revoke は証明書を失効させ CRL を更新します。
+func Revoke(cfg Config, prof Profile) error {
+	if prof.CN == "" || strings.Contains(prof.CN, "..") || strings.ContainsAny(prof.CN, "/\\") {
+		return issue.ErrInvalidCN
+	}
+	if cfg.CA.Key == "" {
+		cfg.CA.Key = filepath.FromSlash("certs/ca/key.pem")
+	}
+	if cfg.CA.Cert == "" {
+		cfg.CA.Cert = filepath.FromSlash("certs/ca/cert.pem")
+	}
+	crlPath := filepath.Join(filepath.Dir(cfg.CA.Cert), "crl.pem")
+	certPath := filepath.Join("certs", prof.CN, "cert.pem")
+
+	cert, err := issue.ReadCert(certPath)
+	if err != nil {
+		return err
+	}
+	caCert, err := issue.ReadCert(cfg.CA.Cert)
+	if err != nil {
+		return err
+	}
+	keyAny, err := issue.ReadKey(cfg.CA.Key)
+	if err != nil {
+		return err
+	}
+	signer, ok := keyAny.(crypto.Signer)
+	if !ok {
+		return errors.New("ca key is not signer")
+	}
+
+	data, err := os.ReadFile(crlPath)
+	if err != nil {
+		return err
+	}
+	blk, _ := pem.Decode(data)
+	if blk == nil {
+		return errors.New("invalid crl pem")
+	}
+	var revoked []x509.RevocationListEntry
+	number := big.NewInt(1)
+	if len(blk.Bytes) > 0 {
+		rl, err := x509.ParseRevocationList(blk.Bytes)
+		if err != nil {
+			return err
+		}
+		revoked = rl.RevokedCertificateEntries
+		if rl.Number != nil {
+			number = new(big.Int).Add(rl.Number, big.NewInt(1))
+		}
+	}
+	revoked = append(revoked, x509.RevocationListEntry{SerialNumber: cert.SerialNumber, RevocationTime: time.Now()})
+
+	tmpl := &x509.RevocationList{
+		SignatureAlgorithm:        caCert.SignatureAlgorithm,
+		RevokedCertificateEntries: revoked,
+		Number:                    number,
+		ThisUpdate:                time.Now(),
+		NextUpdate:                time.Now().AddDate(0, 0, 30),
+	}
+	der, err := x509.CreateRevocationList(rand.Reader, tmpl, caCert, signer)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(crlPath, pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: der}), 0644)
+}

--- a/internal/revoke/revoke_test.go
+++ b/internal/revoke/revoke_test.go
@@ -1,0 +1,121 @@
+package revoke
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"orecert/internal/ca"
+)
+
+func createCA(t *testing.T, dir string) Config {
+	t.Helper()
+	cfg := Config{}
+	cfg.CA.Key = filepath.Join(dir, "certs", "ca", "key.pem")
+	cfg.CA.Cert = filepath.Join(dir, "certs", "ca", "cert.pem")
+	if err := ca.InitCA(ca.Config{CA: cfg.CA}); err != nil {
+		t.Fatalf("init ca: %v", err)
+	}
+	return cfg
+}
+
+func issueCert(t *testing.T, dir, cn string, cfg Config) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	keyPath := filepath.Join(dir, "certs", cn, "key.pem")
+	os.MkdirAll(filepath.Dir(keyPath), 0755)
+	os.WriteFile(keyPath, keyPEM, 0600)
+
+	caCertBytes, _ := os.ReadFile(cfg.CA.Cert)
+	caBlock, _ := pem.Decode(caCertBytes)
+	caCert, _ := x509.ParseCertificate(caBlock.Bytes)
+	caKeyBytes, _ := os.ReadFile(cfg.CA.Key)
+	caKeyBlock, _ := pem.Decode(caKeyBytes)
+	caKey, _ := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+
+	tmpl := &x509.Certificate{SerialNumber: bigInt(t), Subject: pkix.Name{CommonName: cn}, NotBefore: time.Now(), NotAfter: time.Now().AddDate(0, 0, 1), KeyUsage: x509.KeyUsageDigitalSignature}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPath := filepath.Join(dir, "certs", cn, "cert.pem")
+	os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0644)
+}
+
+func bigInt(t *testing.T) *big.Int {
+	b, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return b
+}
+
+func TestRevoke_OK(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	issueCert(t, dir, "host", cfg)
+	os.Chdir(dir)
+	prof := Profile{CN: "host"}
+	if err := Revoke(cfg, prof); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join("certs", "ca", "crl.pem"))
+	blk, _ := pem.Decode(data)
+	rl, err := x509.ParseRevocationList(blk.Bytes)
+	if err != nil || len(rl.RevokedCertificateEntries) != 1 {
+		t.Fatalf("crl not updated")
+	}
+}
+
+func TestRevoke_InvalidCN(t *testing.T) {
+	if err := Revoke(Config{}, Profile{CN: "../bad"}); err == nil {
+		t.Fatalf("expected invalid cn")
+	}
+}
+
+func TestRevoke_BadCA(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	os.Chdir(dir)
+	cfg.CA.Cert = filepath.Join(dir, "none.pem")
+	if err := Revoke(cfg, Profile{CN: "none"}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRevoke_BadKey(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	os.Chdir(dir)
+	cfg.CA.Key = filepath.Join(dir, "none.pem")
+	if err := Revoke(cfg, Profile{CN: "none"}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRevoke_NoCert(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	os.Chdir(dir)
+	if err := Revoke(cfg, Profile{CN: "none"}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRevoke_InvalidCRL(t *testing.T) {
+	dir := t.TempDir()
+	cfg := createCA(t, dir)
+	os.Chdir(dir)
+	os.WriteFile(filepath.Join("certs", "ca", "crl.pem"), []byte("BAD"), 0644)
+	issueCert(t, dir, "h", cfg)
+	if err := Revoke(cfg, Profile{CN: "h"}); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- implement CRL revoke functionality
- add version command with version constant
- add tests for revoke and version

## Testing
- `go test ./...`
- `go test ./... -cover`

------
https://chatgpt.com/codex/tasks/task_e_687b6adead6c8320980d15d4dc93663f